### PR TITLE
Improve instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 - Week #1
 
-  - Build the [English Auction](code/week01) contract with `cabal build`.
+  - Build the [English Auction](code/week01) contract with `cabal build` (you may need to run `cabal update` first).
   - Clone the [The Plutus repository](https://github.com/input-output-hk/plutus), check out the correct commit
     as specified in [cabal.project](code/week01/cabal.project).
   - Enter a `nix-shell`.


### PR DESCRIPTION
When running `cabal build`, I ran into this issue:

```
Warning: The package list for 'hackage.haskell.org' does not exist. Run 'cabal
update' to download it.RemoteRepo {remoteRepoName = RepoName
"hackage.haskell.org", remoteRepoURI = http://hackage.haskell.org/,
remoteRepoSecure = Just True, remoteRepoRootKeys =
["fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0","1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42","2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3","0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d","51f0161b906011b52c6613376b1ae937670da69322113a24
6a09f807c62f6921"],
remoteRepoKeyThreshold = 3, remoteRepoShouldTryHttps = True}
Warning: Requested index-state 2021-02-24T00:00:00Z is newer than
'hackage.haskell.org'! Falling back to older state ().
Resolving dependencies...
cabal: Could not resolve dependencies:
[__0] trying: byron-spec-chain-0.1.0.0 (user goal)
[__1] unknown package: microlens-th (dependency of byron-spec-chain)
[__1] fail (backjumping, conflict set: byron-spec-chain, microlens-th)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: byron-spec-chain, microlens-th
```

As described, I needed to run `cabal update` first.  It could be helpful to have it in the README to help some people get started