### PR TITLE
Fix devcontainer.json config to support new non-root user handling

### DIFF
--- a/code/week03/.devcontainer/devcontainer.json
+++ b/code/week03/.devcontainer/devcontainer.json
@@ -1,12 +1,14 @@
 {
     "name": "Plutus Starter Project",
     "image": "plutus-devcontainer:latest",
+
+    "remoteUser": "plutus",
     
     "mounts": [
         // This shares cabal's remote repository state with the host. We don't mount the whole of '.cabal', because
         // 1. '.cabal/config' contains absolute paths that will only make sense on the host, and
         // 2. '.cabal/store' is not necessarily portable to different version of cabal etc.
-        "source=${localEnv:HOME}/.cabal/packages,target=/root/.cabal/packages,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.cabal/packages,target=/home/plutus/.cabal/packages,type=bind,consistency=cached",
     ],
 
     "settings": {

--- a/code/week04/.devcontainer/devcontainer.json
+++ b/code/week04/.devcontainer/devcontainer.json
@@ -1,12 +1,14 @@
 {
     "name": "Plutus Starter Project",
     "image": "plutus-devcontainer:latest",
+
+    "remoteUser": "plutus",
     
     "mounts": [
         // This shares cabal's remote repository state with the host. We don't mount the whole of '.cabal', because
         // 1. '.cabal/config' contains absolute paths that will only make sense on the host, and
         // 2. '.cabal/store' is not necessarily portable to different version of cabal etc.
-        "source=${localEnv:HOME}/.cabal/packages,target=/root/.cabal/packages,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.cabal/packages,target=/home/plutus/.cabal/packages,type=bind,consistency=cached",
     ],
 
     "settings": {


### PR DESCRIPTION
Hi @brunjlar,

after the update of the devcontainer image to handle non-root setup through https://github.com/input-output-hk/plutus/pull/2956, we should also update the `devcontainer.json` as this affects already the plutus version bump from week 3 and onwards.

Please see input-output-hk/plutus-starter@ce7724eb084f466e680cbe6abb7b78347c1692ff as a reference for the new `devcontainer.json`.
