### PR TITLE
Add mustValidateIn constraint to ClaimFirst transaction

### DIFF
--- a/code/week07/src/Week07/EvenOdd.hs
+++ b/code/week07/src/Week07/EvenOdd.hs
@@ -223,7 +223,8 @@ firstGame fp = do
                 logInfo @String "second player did not play"
                 let lookups = Constraints.unspentOutputs (Map.singleton oref o) <>
                               Constraints.otherScript (gameValidator game)
-                    tx'     = Constraints.mustSpendScriptOutput oref (Redeemer $ PlutusTx.toData ClaimFirst)
+                    tx'     = Constraints.mustSpendScriptOutput oref (Redeemer $ PlutusTx.toData ClaimFirst) <>
+                              Constraints.mustValidateIn (from $ 1 + fpPlayDeadline fp)
                 ledgerTx' <- submitTxConstraintsWith @Gaming lookups tx'
                 void $ awaitTxConfirmed $ txId ledgerTx'
                 logInfo @String "reclaimed stake"


### PR DESCRIPTION
Player 1 cannot reclaim the stake, validation fails with message "too early"