### PR TITLE
Fix the week05 tag for Plutus in cabal.project

### DIFF
--- a/code/week05/cabal.project
+++ b/code/week05/cabal.project
@@ -25,7 +25,7 @@ source-repository-package
     prettyprinter-configurable
     quickcheck-dynamic
     word-array
-  tag: 8f1a47674a99ac9bc2aba3231375d8d6de0641d2
+  tag: 8a20664f00d8f396920385947903761a9a897fe0
 
 -- The following sections are copied from the 'plutus' repository cabal.project at the revision
 -- given above.


### PR DESCRIPTION
Github gives the following warning for the tag 8f1a47674a99ac9bc2aba3231375d8d6de0641d2:

> This commit does not belong to any branch on this repository,
and may belong to a fork outside of the repository.

https://github.com/input-output-hk/plutus/commit/8f1a47674a99ac9bc2aba3231375d8d6de0641d2

The result is that `cabal repl` breaks with the following error:
```
fatal: reference is not a tree: 8f1a47674a99ac9bc2aba3231375d8d6de0641d2
```

Solution: use Week 06 tag for Plutus.