### PR TITLE
import warnings fixes

### DIFF
--- a/code/week02/src/Week02/Burn.hs
+++ b/code/week02/src/Week02/Burn.hs
@@ -22,10 +22,9 @@ import           Ledger              hiding (singleton)
 import           Ledger.Constraints  as Constraints
 import qualified Ledger.Scripts      as Scripts
 import           Ledger.Ada          as Ada
-import           Playground.Contract (printJson, printSchemas, ensureKnownCurrencies, stage)
 import           Playground.TH       (mkKnownCurrencies, mkSchemaDefinitions)
 import           Playground.Types    (KnownCurrency (..))
-import           Prelude             (IO, Semigroup (..), String)
+import           Prelude             (Semigroup (..), String)
 import           Text.Printf         (printf)
 
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}

--- a/code/week02/src/Week02/FortyTwo.hs
+++ b/code/week02/src/Week02/FortyTwo.hs
@@ -22,10 +22,9 @@ import           Ledger              hiding (singleton)
 import           Ledger.Constraints  as Constraints
 import qualified Ledger.Scripts      as Scripts
 import           Ledger.Ada          as Ada
-import           Playground.Contract (printJson, printSchemas, ensureKnownCurrencies, stage)
 import           Playground.TH       (mkKnownCurrencies, mkSchemaDefinitions)
 import           Playground.Types    (KnownCurrency (..))
-import           Prelude             (IO, Semigroup (..), String)
+import           Prelude             (Semigroup (..), String)
 import           Text.Printf         (printf)
 
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}

--- a/code/week02/src/Week02/Gift.hs
+++ b/code/week02/src/Week02/Gift.hs
@@ -21,10 +21,9 @@ import           Ledger              hiding (singleton)
 import           Ledger.Constraints  as Constraints
 import qualified Ledger.Scripts      as Scripts
 import           Ledger.Ada          as Ada
-import           Playground.Contract (printJson, printSchemas, ensureKnownCurrencies, stage)
 import           Playground.TH       (mkKnownCurrencies, mkSchemaDefinitions)
 import           Playground.Types    (KnownCurrency (..))
-import           Prelude             (IO, Semigroup (..), String)
+import           Prelude             (Semigroup (..), String)
 import           Text.Printf         (printf)
 
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}


### PR DESCRIPTION
Removes unnecessary import warnings while running cabal run