### PR TITLE
Update plutus code from week01 to 2021-10-08 PAB Release

### DIFF
--- a/code/week01/cabal.project
+++ b/code/week01/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2021-06-10T00:00:00Z
+index-state: 2021-08-14T00:00:00Z
 
 packages: ./.
 
@@ -12,20 +12,34 @@ benchmarks: true
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus.git
-  subdir:
-    freer-extras
-    playground-common
-    plutus-chain-index
-    plutus-core
-    plutus-contract
-    plutus-ledger
-    plutus-ledger-api
-    plutus-tx
-    plutus-tx-plugin
-    prettyprinter-configurable
-    quickcheck-dynamic
-    word-array
-  tag: ea0ca4e9f9821a9dbfc5255fa0f42b6f2b3887c4
+  subdir: doc
+          fake-pab
+          freer-extras
+          marlowe
+          marlowe-actus
+          marlowe-playground-server
+          marlowe-dashboard-server
+          marlowe-symbolic
+          playground-common
+          plutus-benchmark
+          plutus-chain-index
+          plutus-contract
+          plutus-core
+          plutus-errors
+          plutus-ledger
+          plutus-ledger-api
+          plutus-metatheory
+          plutus-pab
+          plutus-playground-server
+          plutus-tx
+          plutus-tx-plugin
+          plutus-use-cases
+          prettyprinter-configurable
+          quickcheck-dynamic
+          web-ghc
+          word-array
+          stubs/plutus-ghc-stub
+  tag: e2cd641501d13715120329092b3a93df35493a44
 
 -- The following sections are copied from the 'plutus' repository cabal.project at the revision
 -- given above.
@@ -39,13 +53,19 @@ source-repository-package
 package eventful-sql-common
   ghc-options: -XDerivingStrategies -XStandaloneDeriving -XUndecidableInstances -XDataKinds -XFlexibleInstances -XMultiParamTypeClasses
 
+-- We never, ever, want this.
+write-ghc-environment-files: never
+
+-- Always build tests and benchmarks.
+tests: true
+benchmarks: true
+
+-- The only sensible test display option
+test-show-details: streaming
+
 allow-newer:
            -- Pins to an old version of Template Haskell, unclear if/when it will be updated
            size-based:template-haskell
-
-           -- The following two dependencies are needed by plutus.
-           , eventful-sql-common:persistent
-           , eventful-sql-common:persistent-template
            , ouroboros-consensus-byron:formatting
            , beam-core:aeson
            , beam-sqlite:aeson
@@ -55,8 +75,6 @@ allow-newer:
 constraints:
   -- big breaking change here, inline-r doens't have an upper bound
   singletons < 3.0
-  -- breaks eventful even more than it already was
-  , persistent-template < 2.12
   -- bizarre issue: in earlier versions they define their own 'GEq', in newer
   -- ones they reuse the one from 'some', but there isn't e.g. a proper version
   -- constraint from dependent-sum-template (which is the library we actually use).
@@ -66,39 +84,56 @@ constraints:
 -- (NOTE this will change to ieee754 in newer versions of nixpkgs).
 extra-packages: ieee, filemanip
 
--- Drops an instance breaking our code. Should be released to Hackage eventually.
+-- These packages appear in our dependency tree and are very slow to build.
+-- Empirically, turning off optimization shaves off ~50% build time.
+-- It also mildly improves recompilation avoidance.
+-- For deve work we don't care about performance so much, so this is okay.
+package cardano-ledger-alonzo
+  optimization: False
+package ouroboros-consensus-shelley
+  optimization: False
+package ouroboros-consensus-cardano
+  optimization: False
+package cardano-api
+  optimization: False
+
+-- https://github.com/Quid2/flat/pull/22 fixes a potential exception
+-- when decoding invalid (e.g. malicious) text literals.
 source-repository-package
   type: git
   location: https://github.com/Quid2/flat.git
-  tag: 95e5d7488451e43062ca84d5376b3adcc465f1cd
+  tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
 
 -- Needs some patches, but upstream seems to be fairly dead (no activity in > 1 year)
 source-repository-package
   type: git
-  location: https://github.com/shmish111/purescript-bridge.git
+  location: https://github.com/input-output-hk/purescript-bridge.git
   tag: 6a92d7853ea514be8b70bab5e72077bf5a510596
 
 source-repository-package
   type: git
-  location: https://github.com/shmish111/servant-purescript.git
-  tag: a76104490499aa72d40c2790d10e9383e0dbde63
+  location: https://github.com/input-output-hk/servant-purescript.git
+  tag: a0c7c7e37c95564061247461aef4be505a853538
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-crypto.git
-  tag: ce8f1934e4b6252084710975bd9bbc0a4648ece4
+  tag: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: a715c7f420770b70bbe95ca51d3dec83866cb1bd
+  tag: 592aa61d657ad5935a33bace1243abce3728b643
   subdir:
+    base-deriving-via
     binary
     binary/test
-    slotting
     cardano-crypto-class
     cardano-crypto-praos
     cardano-crypto-tests
+    measures
+    orphans-deriving-via
+    slotting
     strict-containers
 
 source-repository-package
@@ -111,9 +146,28 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: e50613562d6d4a0f933741fcf590b0f69a1eda67
+  location: https://github.com/input-output-hk/cardano-addresses
+  tag: d2f86caa085402a953920c6714a0de6a50b655ec
   subdir:
+    core
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-wallet
+  tag: ae7569293e94241ef6829139ec02bd91abd069df
+  subdir:
+    lib/text-class
+    lib/strict-non-empty-containers
+    lib/core
+    lib/test-utils
+    lib/numeric
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: 5d37a927046bc7da2887830d8e35cf604622ce09
+  subdir:
+    monoidal-synchronisation
     typed-protocols
     typed-protocols-examples
     ouroboros-network
@@ -124,13 +178,24 @@ source-repository-package
     ouroboros-consensus-cardano
     ouroboros-consensus-shelley
     io-sim
-    io-sim-classes
+    io-classes
     network-mux
+    ntp-client
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 34abfb7f4f5610cabb45396e0496472446a0b2ca
+  -- Important Note: Read below, before changing this!
+  tag: 46f994e216a1f8b36fe4669b47b2a7011b0e153c
+  -- Are you thinking of updating this tag to some other commit?  Please
+  -- ensure that the commit you are about to use is the latest one from
+  -- the *develop* branch of this repo:
+  --   * <https://github.com/input-output-hk/iohk-monitoring-framework/commits/develop>
+  -- (not master!)
+  --
+  -- In particular we rely on the code from this PR:
+  --  * <https://github.com/input-output-hk/iohk-monitoring-framework/pull/622>
+  -- being merged.
   subdir:
     iohk-monitoring
     tracer-transformers
@@ -143,8 +208,8 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a3ef848542961079b7cd53d599e5385198a3035c
+  location: https://github.com/raduom/cardano-ledger-specs
+  tag: ef6bb99782d61316da55470620c7da994cc352b2
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -153,6 +218,7 @@ source-repository-package
     byron/ledger/impl
     byron/ledger/impl/test
     semantics/executable-spec
+    cardano-protocol-tpraos
     semantics/small-steps-test
     shelley/chain-and-ledger/dependencies/non-integer
     shelley/chain-and-ledger/executable-spec
@@ -167,9 +233,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node.git
-  tag: b3cabae6b3bf30a0b1b4e78bc4b67282dabad0a6
+  tag: ed7fdbf65f40f8e194850b87dd8c631fe26154e6
   subdir:
-    cardano-api/test
     cardano-api
     cardano-node
     cardano-cli
@@ -177,16 +242,19 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/optparse-applicative
+  tag: 7497a29cb998721a9068d5725d49461f2bba0e7a
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/Win32-network
-  tag: 94153b676617f8f33abe8d8182c37377d2784bd1
+  tag: 3825d3abf75f83f406c1f7161883c438dac7277d
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/hedgehog-extras
-  tag: 8bcd3c9dc22cc44f9fcfe161f4638a384fc7a187
+  tag: edf6945007177a638fbeb8802397f3a6f4e47c14
 
--- The following dependencies are not mirrored in the
--- stack.yaml file, but they are needed regardless by cabal.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/goblins

--- a/code/week01/plutus-pioneer-program-week01.cabal
+++ b/code/week01/plutus-pioneer-program-week01.cabal
@@ -15,6 +15,7 @@ library
                      , base ^>=4.14.1.0
                      , containers
                      , playground-common
+                     , plutus-chain-index
                      , plutus-contract
                      , plutus-ledger
                      , plutus-tx-plugin


### PR DESCRIPTION
This updates the lesson 1 to the latest release of Plutus, major changes include using `ChainIndex*` types instead for inspecting UTXOs.

See: https://github.com/input-output-hk/plutus/releases/tag/plutus-pab%2Fv0.0.2