### PR TITLE
Change package name `week02` and `week03` in cabal.project file

### DIFF
--- a/code/cabal.project
+++ b/code/cabal.project
@@ -17,10 +17,10 @@ index-state:
   , hackage.haskell.org 2022-11-14T00:20:02Z
   , cardano-haskell-packages 2022-11-17T04:56:26Z
 
-packages: 
+packages:
     Utilities
-    Week02
-    Week03
+    week02
+    week03
 
 -- We never, ever, want this.
 write-ghc-environment-files: never
@@ -183,8 +183,8 @@ source-repository-package
       libs/small-steps-test
       libs/non-integral
 
--- library for unit tests of Plutus scripts                                                                                       
+-- library for unit tests of Plutus scripts
 source-repository-package
-   type: git                                                                                                                         
+   type: git
    location: https://github.com/geniusyield/plutus-simple-model
    tag: d710c4c5400ff7072fe89c337c1cdd0128dc5d99


### PR DESCRIPTION
When i run `cabal update` in my local computer, it throw error about `Week02` and `Week03` not found.
So we need to change as bellow (from upper case to lower case).
```
packages:
    Utilities
    week02
    week03
```