### PR TITLE
Fix paths in scripts

### DIFF
--- a/code/Week02/scripts/collect-gift.sh
+++ b/code/Week02/scripts/collect-gift.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-assets=/workspaces/plutus-pioneer-program/code/Week02/assets
-keypath=/workspaces/plutus-pioneer-program/keys
+assets=/workspace/code/Week02/assets
+keypath=/workspace/keys
 name="$1"
 collateral="$2"
 txin="$3"

--- a/code/Week02/scripts/make-gift.sh
+++ b/code/Week02/scripts/make-gift.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-assets=/workspaces/plutus-pioneer-program/code/Week02/assets
-keypath=/workspaces/plutus-pioneer-program/keys
+assets=/workspace/code/Week02/assets
+keypath=/workspace/keys
 name="$1"
 txin="$2"
 body="$assets/gift.txbody"

--- a/scripts/create-key-pair.sh
+++ b/scripts/create-key-pair.sh
@@ -5,7 +5,7 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-path=/workspaces/plutus-pioneer-program/keys
+path=/workspace/keys
 mkdir -p "$path"
 
 vkey="$path/$1.vkey"


### PR DESCRIPTION
Noticed that `scripts/create-key-pair.sh` created its output files in `/workspaces/plutus-pioneer-program/keys` inside the dev container, instead of in my local `./keys` directory. Hence the fix.